### PR TITLE
[FEED-637] - Removed silicone from nsfw words list

### DIFF
--- a/src/config/en_US.json
+++ b/src/config/en_US.json
@@ -383,7 +383,6 @@
   "shity": ["sexual"],
   "shiz": ["inappropriate"],
   "shiznit": ["inappropriate"],
-  "silicone": ["inappropriate"],
   "skank": ["insult"],
   "skeet": ["sexual"],
   "skullfuck": ["sexual"],


### PR DESCRIPTION
https://joinhoney.atlassian.net/browse/FEED-637

Since a large majority of silicone products are sfw kitchen products, we want to remove it from the nsfw words list